### PR TITLE
First cut of Zone service

### DIFF
--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -49,6 +49,11 @@ defmodule Dnsimple do
     """
     def patch(client, url, body \\ "", headers \\ [], options \\ []), do: request(client, :patch, url, body, headers, options)
 
+    @doc """
+    Issues a DELETE request to the given url.
+    """
+    def delete(client, url, headers \\ [], options \\ []), do: request(client, :delete, url, "", headers, options)
+
     def request(client, method, url, body \\ "", headers \\ [], options \\ []) do
       headers = headers ++ [
         {"Accept", "application/json"},

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -44,6 +44,11 @@ defmodule Dnsimple do
     """
     def post(client, url, body \\ "", headers \\ [], options \\ []), do: request(client, :post, url, body, headers, options)
 
+    @doc """
+    Issues a PATCH request to the given url.
+    """
+    def patch(client, url, body \\ "", headers \\ [], options \\ []), do: request(client, :patch, url, body, headers, options)
+
     def request(client, method, url, body \\ "", headers \\ [], options \\ []) do
       headers = headers ++ [
         {"Accept", "application/json"},

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -39,6 +39,11 @@ defmodule Dnsimple do
     """
     def get(client, url, headers \\ [], options \\ []), do: request(client, :get, url, "", headers, options)
 
+    @doc """
+    Issues a POST request to the given url.
+    """
+    def post(client, url, body \\ "", headers \\ [], options \\ []), do: request(client, :post, url, body, headers, options)
+
     def request(client, method, url, body \\ "", headers \\ [], options \\ []) do
       headers = headers ++ [
         {"Accept", "application/json"},

--- a/lib/dnsimple/record.ex
+++ b/lib/dnsimple/record.ex
@@ -9,5 +9,13 @@ defmodule Dnsimple.Record do
     content: String.t, ttl: integer, priority: integer, type: String.t,
     system_record: boolean, created_at: String.t, updated_at: String.t
   }
+
+  def to_json(record) do
+    record
+    |> Map.from_struct
+    |> Dict.take([:name, :content, :ttl, :priority])
+    |> Poison.encode!
+  end
+
 end
 

--- a/lib/dnsimple/record.ex
+++ b/lib/dnsimple/record.ex
@@ -1,0 +1,13 @@
+defmodule Dnsimple.Record do
+  defstruct [
+    :id, :zone_id, :parent_id, :name,
+    :content, :ttl, :priority, :type,
+    :system_record, :created_at, :updated_at
+  ]
+  @type t :: %__MODULE__{
+    id: integer, zone_id: String.t, parent_id: integer, name: String.t,
+    content: String.t, ttl: integer, priority: integer, type: String.t,
+    system_record: boolean, created_at: String.t, updated_at: String.t
+  }
+end
+

--- a/lib/dnsimple/records_service.ex
+++ b/lib/dnsimple/records_service.ex
@@ -39,4 +39,14 @@ defmodule Dnsimple.RecordsService do
     |> Map.get("data")
     |> Dnsimple.Utils.single_to_struct(Record)
   end
+
+  @spec update(Client.t, String.t | integer, String.t | integer, Record.t, Keyword.t) :: Record.t
+  def update(client, account_id, zone_id, record, options) do
+    body = Record.to_json(record)
+    response = Client.patch(client, Client.versioned("#{account_id}/zones/#{zone_id}/records/#{record.id}"), body, options)
+    response.body
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Dnsimple.Utils.single_to_struct(Record)
+  end
 end

--- a/lib/dnsimple/records_service.ex
+++ b/lib/dnsimple/records_service.ex
@@ -49,4 +49,10 @@ defmodule Dnsimple.RecordsService do
     |> Map.get("data")
     |> Dnsimple.Utils.single_to_struct(Record)
   end
+
+  @spec delete(Client.t, String.t | integer, String.t | integer, Record.t, Keyword.t) :: :ok
+  def delete(client, account_id, zone_id, record, options) do
+    _response = Client.delete(client, Client.versioned("#{account_id}/zones/#{zone_id}/records/#{record.id}"), options)
+    :ok
+  end
 end

--- a/lib/dnsimple/records_service.ex
+++ b/lib/dnsimple/records_service.ex
@@ -30,4 +30,13 @@ defmodule Dnsimple.RecordsService do
     |> Dnsimple.Utils.collection_to_struct(Record)
   end
 
+  @spec create(Client.t, String.t | integer, String.t | integer, Record.t, Keyword.t) :: Record.t
+  def create(client, account_id, zone_id, record, options) do
+    body = Record.to_json(record)
+    response = Client.post(client, Client.versioned("#{account_id}/zones/#{zone_id}/records"), body, options)
+    response.body
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Dnsimple.Utils.single_to_struct(Record)
+  end
 end

--- a/lib/dnsimple/records_service.ex
+++ b/lib/dnsimple/records_service.ex
@@ -1,0 +1,33 @@
+defmodule Dnsimple.RecordsService do
+  alias Dnsimple.Client
+  alias Dnsimple.Record
+
+  @spec record(Client.t, String.t | integer, integer, Keyword.t) :: Record.t
+  def record(client, zone_id, record_id, options \\ []) do
+    record(client, "_", zone_id, record_id, options)
+  end
+
+  @spec record(Client.t, String.t | integer, String.t | integer, integer, Keyword.t) :: Record.t
+  def record(client, account_id, zone_id, record_id, options) do
+    response = Client.get(client, Client.versioned("#{account_id}/zones/#{zone_id}/records/#{record_id}"), options)
+    response.body
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Dnsimple.Utils.single_to_struct(Record)
+  end
+
+  @spec records(Client.t, String.t | integer, Keyword.t) :: [Record.t]
+  def records(client, zone_id, options \\ []) do
+    records(client, "_", zone_id, options)
+  end
+
+  @spec records(Client.t, String.t | integer, String.t | integer, Keyword.t) :: [Record.t]
+  def records(client, account_id, zone_id, options) do
+    response = Client.get(client, Client.versioned("#{account_id}/zones/#{zone_id}/records"), options)
+    response.body
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Dnsimple.Utils.collection_to_struct(Record)
+  end
+
+end

--- a/lib/dnsimple/zone.ex
+++ b/lib/dnsimple/zone.ex
@@ -1,0 +1,11 @@
+defmodule Dnsimple.Zone do
+  defstruct [
+    :id, :account_id, :name,
+    :reverse, :created_at, :updated_at
+  ]
+  @type t :: %__MODULE__{
+    id: integer, account_id: integer, name: String.t,
+    reverse: boolean, created_at: String.t, updated_at: String.t,
+  }
+end
+

--- a/lib/dnsimple/zones_service.ex
+++ b/lib/dnsimple/zones_service.ex
@@ -2,12 +2,12 @@ defmodule Dnsimple.ZonesService do
   alias Dnsimple.Client
   alias Dnsimple.Zone
 
-  @spec zone(Client.t, String.t | integer, Keyword.t) :: [Zone.t]
+  @spec zone(Client.t, String.t | integer, Keyword.t) :: Zone.t
   def zone(client, zone_id, options \\ []) do
     zone(client, "_", zone_id, options)
   end
 
-  @spec zone(Client.t, String.t | integer, String.t | integer, Keyword.t) :: [Zone.t]
+  @spec zone(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Zone.t
   def zone(client, account_id, zone_id, options) do
     response = Client.get(client, Client.versioned("#{account_id}/zones/#{zone_id}"), options)
     response.body
@@ -16,4 +16,3 @@ defmodule Dnsimple.ZonesService do
     |> Dnsimple.Utils.single_to_struct(Zone)
   end
 end
-

--- a/lib/dnsimple/zones_service.ex
+++ b/lib/dnsimple/zones_service.ex
@@ -2,6 +2,20 @@ defmodule Dnsimple.ZonesService do
   alias Dnsimple.Client
   alias Dnsimple.Zone
 
+  @spec zones(Client.t, Keyword.t) :: [Zone.t]
+  def zones(client, options \\ []) do
+    zones(client, "_", options)
+  end
+
+  @spec zones(Client.t, String.t | integer, Keyword.t) :: [Zone.t]
+  def zones(client, account_id, options) do
+    response = Client.get(client, Client.versioned("#{account_id}/zones"), options)
+    response.body
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Dnsimple.Utils.collection_to_struct(Zone)
+  end
+
   @spec zone(Client.t, String.t | integer, Keyword.t) :: Zone.t
   def zone(client, zone_id, options \\ []) do
     zone(client, "_", zone_id, options)

--- a/lib/dnsimple/zones_service.ex
+++ b/lib/dnsimple/zones_service.ex
@@ -1,0 +1,19 @@
+defmodule Dnsimple.ZonesService do
+  alias Dnsimple.Client
+  alias Dnsimple.Zone
+
+  @spec zone(Client.t, String.t | integer, Keyword.t) :: [Zone.t]
+  def zone(client, zone_id, options \\ []) do
+    zone(client, "_", zone_id, options)
+  end
+
+  @spec zone(Client.t, String.t | integer, String.t | integer, Keyword.t) :: [Zone.t]
+  def zone(client, account_id, zone_id, options) do
+    response = Client.get(client, Client.versioned("#{account_id}/zones/#{zone_id}"), options)
+    response.body
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Dnsimple.Utils.single_to_struct(Zone)
+  end
+end
+

--- a/test/dnsimple_records_service_test.exs
+++ b/test/dnsimple_records_service_test.exs
@@ -88,5 +88,13 @@ defmodule DnsimpleRecordsServiceTest do
       assert response.content == "altered-text-content"
     end
   end
+
+  test ".delete builds the correct request" do
+    r = %Dnsimple.Record{id: 2, name: "subdomain", content: "altered-text-content", type: "TXT", ttl: 600}
+    fixture = ExvcrUtils.response_fixture("deleteZoneRecord/success.http", [url: @client.base_url <> "v2/1010/zones/example.weppos/records/2", method: :delete])
+    use_cassette :stub, fixture do
+      assert :ok == @service.delete(@client, 1010, "example.weppos", r, [])
+    end
+  end
 end
 

--- a/test/dnsimple_records_service_test.exs
+++ b/test/dnsimple_records_service_test.exs
@@ -41,5 +41,29 @@ defmodule DnsimpleRecordsServiceTest do
       assert response.content == "example-alias.com"
     end
   end
+
+
+  test ".create builds the correct request" do
+    r = %Dnsimple.Record{name: "alpha", content: "some-text-content", type: "TXT", ttl: 600}
+    rb = Dnsimple.Record.to_json(r)
+    fixture = ExvcrUtils.response_fixture("createZoneRecord/success.http", [url: @client.base_url <> "v2/1010/zones/example.weppos/records", method: :post, request_body: rb])
+    use_cassette :stub, fixture do
+      @service.create(@client, 1010, "example.weppos", r, [])
+    end
+  end
+
+  test ".create returns a Dnsimple.Record " do
+    r = %Dnsimple.Record{name: "alpha", content: "some-text-content", type: "TXT", ttl: 600}
+    rb = Dnsimple.Record.to_json(r)
+    fixture = ExvcrUtils.response_fixture("createZoneRecord/success.http", [url: @client.base_url <> "v2/1010/zones/example.weppos/records", method: :post, request_body: rb])
+    use_cassette :stub, fixture do
+      response = @service.create(@client, 1010, "example.weppos", r, [])
+      assert is_map(response)
+      assert response.__struct__ == Dnsimple.Record
+      assert response.id == 2
+      assert response.type == "TXT"
+      assert response.content == "some-text-content"
+    end
+  end
 end
 

--- a/test/dnsimple_records_service_test.exs
+++ b/test/dnsimple_records_service_test.exs
@@ -1,0 +1,45 @@
+defmodule DnsimpleRecordsServiceTest do
+  use TestCase, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  doctest Dnsimple.RecordsService
+
+  @service Dnsimple.RecordsService
+  @client %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test/"}
+
+
+  test ".records builds the correct request" do
+    fixture = ExvcrUtils.response_fixture("listZoneRecords/success.http", [url: @client.base_url <> "v2/1010/zones/example.com/records"])
+    use_cassette :stub, fixture do
+      @service.records(@client, 1010, "example.com", [])
+    end
+  end
+
+  test ".records returns a list of Dnsimple.Record" do
+    use_cassette :stub, ExvcrUtils.response_fixture("listZoneRecords/success.http", [url: "~r/\/records$/"]) do
+      response = @service.records(@client, 1010, "example.com", [])
+      assert is_list(response)
+      assert length(response) == 7
+      assert Enum.all?(response, fn(single) -> single.__struct__ == Dnsimple.Record end)
+      assert Enum.all?(response, fn(single) -> is_integer(single.id) end)
+    end
+  end
+
+  test ".record builds the correct request" do
+    fixture = ExvcrUtils.response_fixture("getZoneRecord/success.http", [url: @client.base_url <> "v2/_/zones/example.weppos/records/1234"])
+    use_cassette :stub, fixture do
+      @service.record(@client, "example.weppos", 1234)
+    end
+  end
+
+  test ".records returns a Dnsimple.Record " do
+    use_cassette :stub, ExvcrUtils.response_fixture("getZoneRecord/success.http", [url: "~r/\/records/.+$/"]) do
+      response = @service.record(@client, "example.weppos", 1)
+      assert is_map(response)
+      assert response.__struct__ == Dnsimple.Record
+      assert response.id == 1
+      assert response.type == "ALIAS"
+      assert response.content == "example-alias.com"
+    end
+  end
+end
+

--- a/test/dnsimple_records_service_test.exs
+++ b/test/dnsimple_records_service_test.exs
@@ -65,5 +65,28 @@ defmodule DnsimpleRecordsServiceTest do
       assert response.content == "some-text-content"
     end
   end
+
+  test ".update builds the correct request" do
+    r = %Dnsimple.Record{id: 2, name: "subdomain", content: "altered-text-content", type: "TXT", ttl: 600}
+    rb = Dnsimple.Record.to_json(r)
+    fixture = ExvcrUtils.response_fixture("updateZoneRecord/success.http", [url: @client.base_url <> "v2/1010/zones/example.weppos/records/2", method: :patch, request_body: rb])
+    use_cassette :stub, fixture do
+      @service.update(@client, 1010, "example.weppos", r, [])
+    end
+  end
+
+  test ".update returns a Dnsimple.Record " do
+    r = %Dnsimple.Record{id: 2, name: "subdomain", content: "altered-text-content", type: "TXT", ttl: 600}
+    rb = Dnsimple.Record.to_json(r)
+    fixture = ExvcrUtils.response_fixture("updateZoneRecord/success.http", [url: @client.base_url <> "v2/1010/zones/example.weppos/records/2", method: :patch, request_body: rb])
+    use_cassette :stub, fixture do
+      response = @service.update(@client, 1010, "example.weppos", r, [])
+      assert is_map(response)
+      assert response.__struct__ == Dnsimple.Record
+      assert response.id == 2
+      assert response.type == "TXT"
+      assert response.content == "altered-text-content"
+    end
+  end
 end
 

--- a/test/dnsimple_zones_service_test.exs
+++ b/test/dnsimple_zones_service_test.exs
@@ -7,6 +7,30 @@ defmodule DnsimpleZonesServiceTest do
   @client %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test/"}
 
 
+  test ".zones/2 builds the correct request" do
+    fixture = ExvcrUtils.response_fixture("listZones/success.http", [url: @client.base_url <> "v2/_/zones"])
+    use_cassette :stub, fixture do
+      @service.zones(@client)
+    end
+  end
+
+  test ".zones/3 builds the correct request" do
+    fixture = ExvcrUtils.response_fixture("listZones/success.http", [url: @client.base_url <> "v2/1010/zones"])
+    use_cassette :stub, fixture do
+      @service.zones(@client, 1010, [])
+    end
+  end
+
+  test ".zones returns a list of Dnsimple.Zone" do
+    use_cassette :stub, ExvcrUtils.response_fixture("listZones/success.http", [url: "~r/\/zones$/"]) do
+      response = @service.zones(@client, 1010, [])
+      assert is_list(response)
+      assert length(response) == 2
+      assert Enum.all?(response, fn(single) -> single.__struct__ == Dnsimple.Zone end)
+      assert Enum.all?(response, fn(single) -> is_integer(single.id) end)
+    end
+  end
+
   test ".zone/3 builds the correct request" do
     fixture = ExvcrUtils.response_fixture("getZone/success.http", [url: @client.base_url <> "v2/_/zones/example.weppos"])
     use_cassette :stub, fixture do

--- a/test/dnsimple_zones_service_test.exs
+++ b/test/dnsimple_zones_service_test.exs
@@ -1,0 +1,36 @@
+defmodule DnsimpleZonesServiceTest do
+  use TestCase, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  doctest Dnsimple.ZonesService
+
+  @service Dnsimple.ZonesService
+  @client %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test/"}
+
+
+  test ".zone/3 builds the correct request" do
+    fixture = ExvcrUtils.response_fixture("getZone/success.http", [url: @client.base_url <> "v2/_/zones/example.weppos"])
+    use_cassette :stub, fixture do
+      @service.zone(@client, "example.weppos")
+    end
+  end
+
+  test ".zone/4 builds the correct request" do
+    fixture = ExvcrUtils.response_fixture("getZone/success.http", [url: @client.base_url <> "v2/1010/zones/example.weppos"])
+    use_cassette :stub, fixture do
+      @service.zone(@client, 1010, "example.weppos", [])
+    end
+  end
+
+  test ".zone returns a Dnsimple.Zone" do
+    use_cassette :stub, ExvcrUtils.response_fixture("getZone/success.http", [url: "~r/\/zones/.+$/"]) do
+      response = @service.zone(@client, "example.weppos")
+      assert is_map(response)
+      assert response.__struct__ == Dnsimple.Zone
+      assert response.id == 1
+      assert response.name == "example.com"
+    end
+  end
+
+
+end
+

--- a/test/fixtures.http/createZoneRecord/success.http
+++ b/test/fixtures.http/createZoneRecord/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Tue, 09 Feb 2016 22:09:55 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 201 Created
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3996
+X-RateLimit-Reset: 1455059131
+ETag: W/"4c23a705490c4a8e58a159f38334dXXX"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 2b1d032e-0bdc-4945-a1e3-1706cd7ee766
+X-Runtime: 0.151376
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":2,"zone_id":"example.com","parent_id":null,"name":"alpha","content":"some-text-content","ttl":600,"priority":null,"type":"TXT","system_record":false,"created_at":"2016-02-09T22:09:55.335Z","updated_at":"2016-02-09T22:09:55.335Z"}}  

--- a/test/fixtures.http/deleteZoneRecord/success.http
+++ b/test/fixtures.http/deleteZoneRecord/success.http
@@ -1,0 +1,12 @@
+HTTP/1.1 204 No Content
+Server: nginx
+Date: Wed, 10 Feb 2016 23:22:24 GMT
+Connection: keep-alive
+Status: 204 No Content
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3998
+X-RateLimit-Reset: 1455149502
+Cache-Control: no-cache
+X-Request-Id: eb57c78f-3479-4ee7-bfb3-15821f73272f
+X-Runtime: 0.086806
+Strict-Transport-Security: max-age=31536000

--- a/test/fixtures.http/getZone/success.http
+++ b/test/fixtures.http/getZone/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sun, 07 Feb 2016 18:52:12 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3993
+X-RateLimit-Reset: 1454873747
+ETag: W/"a9e4d37f0609b985f1693f41ebe09XXX"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: e0055435-8f98-4b61-9570-0464a743a7e2
+X-Runtime: 0.016366
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"account_id":1010,"name":"example.com","reverse":false,"created_at":"2016-02-01T14:03:25.157Z","updated_at":"2016-02-01T14:06:56.271Z"}}

--- a/test/fixtures.http/getZoneRecord/success.http
+++ b/test/fixtures.http/getZoneRecord/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 09 Feb 2016 04:30:56 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3998
+X-RateLimit-Reset: 1454995838
+ETag: W/"68767fad1babc7c044ac60cc365f0XXX"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: fdd05bcc-dc4a-4f24-9458-9bf950c13e3d
+X-Runtime: 0.088866
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"zone_id":"example.com","parent_id":null,"name":"","content":"example-alias.com","ttl":60,"priority":null,"type":"ALIAS","system_record":false,"created_at":"2016-02-01T14:06:56.095Z","updated_at":"2016-02-01T14:06:56.095Z"}}

--- a/test/fixtures.http/listZoneRecords/success.http
+++ b/test/fixtures.http/listZoneRecords/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sun, 07 Feb 2016 18:45:32 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3994
+X-RateLimit-Reset: 1454873747
+ETag: W/"561950b4caaffb724d4936911e030XXX"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: a0e1b332-04ce-4fcb-a20a-29843aa9a729
+X-Runtime: 0.032723
+Strict-Transport-Security: max-age=31536000
+
+{"data":[{"id":1,"zone_id":"example.com","parent_id":null,"name":"","content":"ns1.dnsimple.com admin.dnsimple.com 1454335406 86400 7200 604800 300","ttl":3600,"priority":null,"type":"SOA","system_record":true,"created_at":"2016-02-01T14:03:25.180Z","updated_at":"2016-02-01T14:06:56.259Z"},{"id":2,"zone_id":"example.com","parent_id":null,"name":"","content":"ns1.dnsimple.com","ttl":3600,"priority":null,"type":"NS","system_record":true,"created_at":"2016-02-01T14:03:25.781Z","updated_at":"2016-02-01T14:03:25.781Z"},{"id":3,"zone_id":"example.com","parent_id":null,"name":"","content":"ns2.dnsimple.com","ttl":3600,"priority":null,"type":"NS","system_record":true,"created_at":"2016-02-01T14:03:25.930Z","updated_at":"2016-02-01T14:03:25.930Z"},{"id":4,"zone_id":"example.com","parent_id":null,"name":"","content":"ns3.dnsimple.com","ttl":3600,"priority":null,"type":"NS","system_record":true,"created_at":"2016-02-01T14:03:26.077Z","updated_at":"2016-02-01T14:03:26.077Z"},{"id":5,"zone_id":"example.com","parent_id":null,"name":"","content":"ns4.dnsimple.com","ttl":3600,"priority":null,"type":"NS","system_record":true,"created_at":"2016-02-01T14:03:26.228Z","updated_at":"2016-02-01T14:03:26.228Z"},{"id":6,"zone_id":"example.com","parent_id":null,"name":"","content":"example-alpha.com","ttl":60,"priority":null,"type":"ALIAS","system_record":false,"created_at":"2016-02-01T14:06:56.095Z","updated_at":"2016-02-01T14:06:56.095Z"},{"id":7,"zone_id":"example.com","parent_id":5344902,"name":"","content":"ALIAS for example-alpha.com","ttl":60,"priority":null,"type":"TXT","system_record":false,"created_at":"2016-02-01T14:06:56.240Z","updated_at":"2016-02-01T14:06:56.240Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":7,"total_pages":1}}

--- a/test/fixtures.http/listZones/success.http
+++ b/test/fixtures.http/listZones/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 09 Feb 2016 03:20:10 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3999
+X-RateLimit-Reset: 1454991610
+ETag: W/"eb76b4771a99b40923193b1e3c362XXX"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: bc3b5d09-8eba-4a6c-8d4a-508e90d360e0
+X-Runtime: 0.034462
+Strict-Transport-Security: max-age=31536000
+
+{"data":[{"id":1,"account_id":1010,"name":"example.com","reverse":false,"created_at":"2016-01-09T17:09:52.616Z","updated_at":"2016-01-09T21:28:38.514Z"},{"id":2,"account_id":1010,"name":"example.me","reverse":false,"created_at":"2016-02-01T14:03:25.157Z","updated_at":"2016-02-01T14:06:56.271Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/test/fixtures.http/updateZoneRecord/success.http
+++ b/test/fixtures.http/updateZoneRecord/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 10 Feb 2016 23:11:42 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3999
+X-RateLimit-Reset: 1455149502
+ETag: W/"15d177c01feee4cdfb1bacf4c9a48XXX"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: e77503da-3405-4a82-9af6-2e2fc4f0be24
+X-Runtime: 0.138217
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":2,"zone_id":"example.com","parent_id":null,"name":"subdomain","content":"altered-text-content","ttl":600,"priority":null,"type":"TXT","system_record":false,"created_at":"2016-02-09T22:09:55.335Z","updated_at":"2016-02-10T23:11:42.290Z"}}


### PR DESCRIPTION
Here's my first stab at implementing a ZonesService. I just followed your examples for Domains and tried to make some guesses about how the "_" should be handled for account IDs.

My plan is to continue and work on a RecordsService, using the API path of:
`/v2/#{account_id}/zones/#{zone_id}/records`

I assume that's the correct nesting, right? My goal is to be able to create and modify records for a domain. Looking at the v1 API, it seems like the way to go is:
`/v1/domains/#{domain_id}/records`

Is there going to be a 1-level nesting for records in the v2 API, or will they always be 2 levels deep? In other words, will there be:
`domain -> records`
or always
`domain -> zone -> records`

I don't know what a Zone is meant to represent. Maybe it's a more advanced way to group record sets for a domain. All my domain needs in the past have been very simple.

Please provide any feedback, direction, or otherwise guidance about how I should be proceeding.

Thanks!