### PR TITLE
Add support for registrar domain auto renewal endpoints

### DIFF
--- a/lib/dnsimple/registrar_auto_renewal_service.ex
+++ b/lib/dnsimple/registrar_auto_renewal_service.ex
@@ -1,0 +1,18 @@
+defmodule Dnsimple.RegistrarAutoRenewalService do
+  alias Dnsimple.Client
+  alias Dnsimple.Response
+
+  @doc """
+  Enable auto-renewal for the domain.
+
+  See: https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
+  """
+  @spec enable_auto_renewal(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
+  def enable_auto_renewal(client, account_id, domain_name, headers \\ [], options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/auto_renewal")
+
+    Client.put(client, url, headers, options)
+      |> Response.parse(nil)
+  end
+
+end

--- a/lib/dnsimple/registrar_auto_renewal_service.ex
+++ b/lib/dnsimple/registrar_auto_renewal_service.ex
@@ -15,4 +15,17 @@ defmodule Dnsimple.RegistrarAutoRenewalService do
       |> Response.parse(nil)
   end
 
+  @doc """
+  Disable auto-renewal for the domain.
+
+  See: https://developer.dnsimple.com/v2/registrar/auto-renewal/#disable
+  """
+  @spec disable_auto_renewal(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
+  def disable_auto_renewal(client, account_id, domain_name, headers \\ [], options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/auto_renewal")
+
+    Client.delete(client, url, headers, options)
+      |> Response.parse(nil)
+  end
+
 end

--- a/test/dnsimple_registrar_auto_renewal_service_test.exs
+++ b/test/dnsimple_registrar_auto_renewal_service_test.exs
@@ -20,4 +20,17 @@ defmodule DnsimpleRegistrarAutoRenewalServiceTest do
     end
   end
 
+  test ".disableDomainAutoRenewal" do
+    fixture = "disableDomainAutoRenewal/success.http"
+    method  = "delete"
+    url     = "#{@client.base_url}/v2/1010/registrar/domains/example.com/auto_renewal"
+
+    use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+      {:ok, response} = @service.disable_auto_renewal(@client, "1010", "example.com")
+
+      assert response.__struct__ == Dnsimple.Response
+      assert is_nil(response.data)
+    end
+  end
+
 end

--- a/test/dnsimple_registrar_auto_renewal_service_test.exs
+++ b/test/dnsimple_registrar_auto_renewal_service_test.exs
@@ -1,0 +1,23 @@
+defmodule DnsimpleRegistrarAutoRenewalServiceTest do
+  use TestCase, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  @service Dnsimple.RegistrarAutoRenewalService
+  @client %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test"}
+
+  test ".enableDomainAutoRenewal" do
+    fixture = "enableDomainAutoRenewal/success.http"
+    method  = "put"
+    url     = "#{@client.base_url}/v2/1010/registrar/domains/example.com/auto_renewal"
+    attributes  = []
+    {:ok, body} = Poison.encode(attributes)
+
+    use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do
+      {:ok, response} = @service.enable_auto_renewal(@client, "1010", "example.com")
+
+      assert response.__struct__ == Dnsimple.Response
+      assert is_nil(response.data)
+    end
+  end
+
+end

--- a/test/fixtures.http/disableDomainAutoRenewal/success.http
+++ b/test/fixtures.http/disableDomainAutoRenewal/success.http
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+Server: nginx
+Date: Fri, 12 Feb 2016 11:15:46 GMT
+Connection: keep-alive
+Status: 204 No Content
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3996
+X-RateLimit-Reset: 1455279163
+Cache-Control: no-cache
+X-Request-Id: 6a8e83f1-f80c-4dc0-a462-d63c932a59bb
+X-Runtime: 0.509466
+Strict-Transport-Security: max-age=31536000
+

--- a/test/fixtures.http/enableDomainAutoRenewal/success.http
+++ b/test/fixtures.http/enableDomainAutoRenewal/success.http
@@ -1,0 +1,13 @@
+HTTP/1.1 204 No Content
+Server: nginx
+Date: Fri, 12 Feb 2016 11:13:38 GMT
+Connection: keep-alive
+Status: 204 No Content
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3997
+X-RateLimit-Reset: 1455279163
+Cache-Control: no-cache
+X-Request-Id: 46e77cb2-157e-4740-8cd3-f20d4d653c95
+X-Runtime: 7.702967
+Strict-Transport-Security: max-age=31536000
+


### PR DESCRIPTION
This is how they work work: 

```
iex(2)> Dnsimple.RegistrarAutoRenewalService.enable_auto_renewal(client, 63, "aaa-0001.com")                       {:ok,
 %Dnsimple.Response{data: nil,
  http_response: %HTTPoison.Response{body: "",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 15:56:40 GMT"},
    {"Connection", "keep-alive"}, {"Status", "204 No Content"},
    {"X-RateLimit-Limit", "2400"}, {"X-RateLimit-Remaining", "2399"},
    {"X-RateLimit-Reset", "1460393800"}, {"Cache-Control", "no-cache"},
    {"X-Request-Id", "d141a0d3-e2ed-4fac-8be6-e26cc172dcd1"},
    {"X-Runtime", "0.722942"},
    {"Strict-Transport-Security", "max-age=31536000"}], status_code: 204},
  rate_limit: 2400, rate_limit_remaining: 2399, rate_limit_reset: 1460393800}}
iex(3)> Dnsimple.RegistrarAutoRenewalService.disable_auto_renewal(client, 63, "aaa-0001.com")
{:ok,
 %Dnsimple.Response{data: nil,
  http_response: %HTTPoison.Response{body: "",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 15:57:09 GMT"},
    {"Connection", "keep-alive"}, {"Status", "204 No Content"},
    {"X-RateLimit-Limit", "2400"}, {"X-RateLimit-Remaining", "2398"},
    {"X-RateLimit-Reset", "1460393800"}, {"Cache-Control", "no-cache"},
    {"X-Request-Id", "c6608de5-db91-4a43-a746-e00ce215b3f9"},
    {"X-Runtime", "0.454067"},
    {"Strict-Transport-Security", "max-age=31536000"}], status_code: 204},
  rate_limit: 2400, rate_limit_remaining: 2398, rate_limit_reset: 1460393800}}
```