### PR TITLE
Add support for registrar whois privacy endpoints

### DIFF
--- a/lib/dnsimple/registrar_whois_privacy_service.ex
+++ b/lib/dnsimple/registrar_whois_privacy_service.ex
@@ -29,4 +29,17 @@ defmodule Dnsimple.RegistrarWhoisPrivacyService do
       |> Response.parse(WhoisPrivacy)
   end
 
+  @doc """
+  Disables the whois privacy for the domain.
+
+  See: https://developer.dnsimple.com/v2/registrar/whois-privacy/#disable
+  """
+  @spec disable_whois_privacy(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
+  def disable_whois_privacy(client, account_id, domain_name, headers \\ [], options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
+
+    Client.delete(client, url, headers, options)
+      |> Response.parse(WhoisPrivacy)
+  end
+
 end

--- a/lib/dnsimple/registrar_whois_privacy_service.ex
+++ b/lib/dnsimple/registrar_whois_privacy_service.ex
@@ -16,4 +16,17 @@ defmodule Dnsimple.RegistrarWhoisPrivacyService do
       |> Response.parse(WhoisPrivacy)
   end
 
+  @doc """
+  Enables the whois privacy for the domain.
+
+  See: https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
+  """
+  @spec enable_whois_privacy(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
+  def enable_whois_privacy(client, account_id, domain_name, headers \\ [], options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
+
+    Client.put(client, url, _body = [], headers, options)
+      |> Response.parse(WhoisPrivacy)
+  end
+
 end

--- a/lib/dnsimple/registrar_whois_privacy_service.ex
+++ b/lib/dnsimple/registrar_whois_privacy_service.ex
@@ -1,0 +1,19 @@
+defmodule Dnsimple.RegistrarWhoisPrivacyService do
+  alias Dnsimple.Client
+  alias Dnsimple.Response
+  alias Dnsimple.WhoisPrivacy
+
+  @doc """
+  Gets the whois privacy for the domain.
+
+  See: https://developer.dnsimple.com/v2/registrar/whois-privacy/#get
+  """
+  @spec whois_privacy(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
+  def whois_privacy(client, account_id, domain_name, headers \\ [], options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
+
+    Client.get(client, url, headers, options)
+      |> Response.parse(WhoisPrivacy)
+  end
+
+end

--- a/lib/dnsimple/whois_privacy.ex
+++ b/lib/dnsimple/whois_privacy.ex
@@ -1,0 +1,11 @@
+defmodule Dnsimple.WhoisPrivacy do
+  defstruct [:id, :domain_id, :enabled, :expires_on, :created_at, :updated_at]
+  @type t :: %__MODULE__{
+    id: Integer.t,
+    domain_id: Integer.t,
+    enabled: Boolean.t,
+    expires_on: String.t,
+    created_at: String.t,
+    updated_at: String.t,
+  }
+end

--- a/test/dnsimple_registrar_whois_privacy_service_test.exs
+++ b/test/dnsimple_registrar_whois_privacy_service_test.exs
@@ -49,4 +49,25 @@ defmodule DnsimpleRegistrarWhoisPrivacyServiceTest do
     end
   end
 
+  test ".disable_whois_privacy" do
+    fixture = "disableWhoisPrivacy/success.http"
+    method  = "delete"
+    url     = "#{@client.base_url}/v2/1010/registrar/domains/example.com/whois_privacy"
+
+    use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+      {:ok, response} = @service.disable_whois_privacy(@client, "1010", "example.com")
+
+      assert response.__struct__ == Dnsimple.Response
+      assert response.data.__struct__ == Dnsimple.WhoisPrivacy
+      assert response.data == %Dnsimple.WhoisPrivacy{
+        id: 1,
+        domain_id: 2,
+        enabled: false,
+        expires_on: "2017-02-13",
+        created_at: "2016-02-13T14:34:50.135Z",
+        updated_at: "2016-02-13T14:36:38.964Z",
+      }
+    end
+  end
+
 end

--- a/test/dnsimple_registrar_whois_privacy_service_test.exs
+++ b/test/dnsimple_registrar_whois_privacy_service_test.exs
@@ -26,4 +26,27 @@ defmodule DnsimpleRegistrarWhoisPrivacyServiceTest do
     end
   end
 
+  test ".enable_whois_privacy" do
+    fixture     = "enableWhoisPrivacy/created.http"
+    method      = "put"
+    url         = "#{@client.base_url}/v2/1010/registrar/domains/example.com/whois_privacy"
+    attributes  = []
+    {:ok, body} = Poison.encode(attributes)
+
+    use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do
+      {:ok, response} = @service.enable_whois_privacy(@client, "1010", "example.com")
+
+      assert response.__struct__ == Dnsimple.Response
+      assert response.data.__struct__ == Dnsimple.WhoisPrivacy
+      assert response.data == %Dnsimple.WhoisPrivacy{
+        id: 1,
+        domain_id: 2,
+        enabled: nil,
+        expires_on: nil,
+        created_at: "2016-02-13T14:34:50.135Z",
+        updated_at: "2016-02-13T14:34:50.135Z",
+      }
+    end
+  end
+
 end

--- a/test/dnsimple_registrar_whois_privacy_service_test.exs
+++ b/test/dnsimple_registrar_whois_privacy_service_test.exs
@@ -1,0 +1,29 @@
+defmodule DnsimpleRegistrarWhoisPrivacyServiceTest do
+  use TestCase, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+
+  @service Dnsimple.RegistrarWhoisPrivacyService
+  @client %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test"}
+
+  test ".whois_privacy" do
+    fixture = "getWhoisPrivacy/success.http"
+    method  = "get"
+    url     = "#{@client.base_url}/v2/1010/registrar/domains/example.com/whois_privacy"
+
+    use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+      {:ok, response} = @service.whois_privacy(@client, "1010", "example.com")
+
+      assert response.__struct__ == Dnsimple.Response
+      assert response.data.__struct__ == Dnsimple.WhoisPrivacy
+      assert response.data == %Dnsimple.WhoisPrivacy{
+        id: 1,
+        domain_id: 2,
+        enabled: true,
+        expires_on: "2017-02-13",
+        created_at: "2016-02-13T14:34:50.135Z",
+        updated_at: "2016-02-13T14:34:52.571Z",
+      }
+    end
+  end
+
+end

--- a/test/fixtures.http/disableWhoisPrivacy/success.http
+++ b/test/fixtures.http/disableWhoisPrivacy/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sat, 13 Feb 2016 14:36:38 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3995
+X-RateLimit-Reset: 1455377134
+ETag: W/"56e3e7f76ba9c84dcab9aef72347edf2"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 4831c4d9-e62e-4710-a999-4ab32a900cea
+X-Runtime: 0.988453
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":2,"expires_on":"2017-02-13","enabled":false,"created_at":"2016-02-13T14:34:50.135Z","updated_at":"2016-02-13T14:36:38.964Z"}}

--- a/test/fixtures.http/enableWhoisPrivacy/created.http
+++ b/test/fixtures.http/enableWhoisPrivacy/created.http
@@ -1,0 +1,17 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Sat, 13 Feb 2016 14:34:52 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 201 Created
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3997
+X-RateLimit-Reset: 1455377135
+ETag: W/"c955cdcda56f131395952576e6ded0b6"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 779eff1a-429c-432a-ad17-617502d62e69
+X-Runtime: 2.563855
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":2,"expires_on":null,"enabled":null,"created_at":"2016-02-13T14:34:50.135Z","updated_at":"2016-02-13T14:34:50.135Z"}}

--- a/test/fixtures.http/enableWhoisPrivacy/success.http
+++ b/test/fixtures.http/enableWhoisPrivacy/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sat, 13 Feb 2016 14:36:49 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3994
+X-RateLimit-Reset: 1455377135
+ETag: W/"1063ebb3e281ca6e1941874002696cd7"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 34453d13-76ba-4f64-ad94-2d536c61826c
+X-Runtime: 1.408974
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":2,"expires_on":"2017-02-13","enabled":true,"created_at":"2016-02-13T14:34:50.135Z","updated_at":"2016-02-13T14:36:48.940Z"}}

--- a/test/fixtures.http/getWhoisPrivacy/success.http
+++ b/test/fixtures.http/getWhoisPrivacy/success.http
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Sat, 13 Feb 2016 14:35:37 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 4000
+X-RateLimit-Remaining: 3996
+X-RateLimit-Reset: 1455377135
+ETag: W/"10be37d45cd224b2178b8a2f86c466ea"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 78afe010-0f54-4d39-9ed3-08c67d545a35
+X-Runtime: 0.031770
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":2,"expires_on":"2017-02-13","enabled":true,"created_at":"2016-02-13T14:34:50.135Z","updated_at":"2016-02-13T14:34:52.571Z"}}


### PR DESCRIPTION
You can see it in action here:

```
iex(2)> Dnsimple.RegistrarWhoisPrivacyService.whois_privacy(client, 63, "aaa-0001.com")                            {:error,
 %Dnsimple.NotFoundError{http_response: %HTTPoison.Response{body: "{\"message\":\"Whois privacy for aaa-0001.com not found\"}",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 17:00:01 GMT"},
    {"Content-Type", "application/json; charset=utf-8"},
    {"Transfer-Encoding", "chunked"}, {"Connection", "keep-alive"},
    {"Status", "404 Not Found"}, {"Cache-Control", "no-cache"},
    {"X-Request-Id", "064e364a-4be9-4008-8219-419308f88374"},
    {"X-Runtime", "0.064443"}], status_code: 404},
  message: "Whois privacy for aaa-0001.com not found"}}

iex(3)> Dnsimple.RegistrarWhoisPrivacyService.enable_whois_privacy(client, 63, "aaa-0001.com")
{:ok,
 %Dnsimple.Response{data: %Dnsimple.WhoisPrivacy{created_at: "2016-04-11T17:00:15.931Z",
   domain_id: 6156, enabled: nil, expires_on: nil, id: 159,
   updated_at: "2016-04-11T17:00:15.931Z"},
  http_response: %HTTPoison.Response{body: "{\"data\":{\"id\":159,\"domain_id\":6156,\"expires_on\":null,\"enabled\":null,\"created_at\":\"2016-04-11T17:00:15.931Z\",\"updated_at\":\"2016-04-11T17:00:15.931Z\"}}",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 17:00:17 GMT"},
    {"Content-Type", "application/json; charset=utf-8"},
    {"Transfer-Encoding", "chunked"}, {"Connection", "keep-alive"},
    {"Status", "201 Created"}, {"X-RateLimit-Limit", "2400"},
    {"X-RateLimit-Remaining", "2399"}, {"X-RateLimit-Reset", "1460397617"},
    {"ETag", "W/\"e0f0b277d2db82d0fd1badaaca4f577c\""},
    {"Cache-Control", "max-age=0, private, must-revalidate"},
    {"X-Request-Id", "29bbe735-a5d7-48c0-954e-75c9b01a431a"},
    {"X-Runtime", "1.331986"},
    {"Strict-Transport-Security", "max-age=31536000"}], status_code: 201},
  rate_limit: 2400, rate_limit_remaining: 2399, rate_limit_reset: 1460397617}}

iex(4)> Dnsimple.RegistrarWhoisPrivacyService.whois_privacy(client, 63, "aaa-0001.com")
{:ok,
 %Dnsimple.Response{data: %Dnsimple.WhoisPrivacy{created_at: "2016-04-11T17:00:15.931Z",
   domain_id: 6156, enabled: true, expires_on: "2017-04-11", id: 159,
   updated_at: "2016-04-11T17:00:17.119Z"},
  http_response: %HTTPoison.Response{body: "{\"data\":{\"id\":159,\"domain_id\":6156,\"expires_on\":\"2017-04-11\",\"enabled\":true,\"created_at\":\"2016-04-11T17:00:15.931Z\",\"updated_at\":\"2016-04-11T17:00:17.119Z\"}}",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 17:00:31 GMT"},
    {"Content-Type", "application/json; charset=utf-8"},
    {"Transfer-Encoding", "chunked"}, {"Connection", "keep-alive"},
    {"Status", "200 OK"}, {"X-RateLimit-Limit", "2400"},
    {"X-RateLimit-Remaining", "2398"}, {"X-RateLimit-Reset", "1460397617"},
    {"ETag", "W/\"a0f9f9c77961732a6064e8b7ed6a19d3\""},
    {"Cache-Control", "max-age=0, private, must-revalidate"},
    {"X-Request-Id", "ece0cf09-831b-499d-bf82-3b0ef4322cd4"},
    {"X-Runtime", "0.110461"},
    {"Strict-Transport-Security", "max-age=31536000"}], status_code: 200},
  rate_limit: 2400, rate_limit_remaining: 2398, rate_limit_reset: 1460397617}}

iex(5)> Dnsimple.RegistrarWhoisPrivacyService.disable_whois_privacy(client, 63, "aaa-0001.com")
{:ok,
 %Dnsimple.Response{data: %Dnsimple.WhoisPrivacy{created_at: "2016-04-11T17:00:15.931Z",
   domain_id: 6156, enabled: false, expires_on: "2017-04-11", id: 159,
   updated_at: "2016-04-11T17:00:48.423Z"},
  http_response: %HTTPoison.Response{body: "{\"data\":{\"id\":159,\"domain_id\":6156,\"expires_on\":\"2017-04-11\",\"enabled\":false,\"created_at\":\"2016-04-11T17:00:15.931Z\",\"updated_at\":\"2016-04-11T17:00:48.423Z\"}}",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 17:00:48 GMT"},
    {"Content-Type", "application/json; charset=utf-8"},
    {"Transfer-Encoding", "chunked"}, {"Connection", "keep-alive"},
    {"Status", "200 OK"}, {"X-RateLimit-Limit", "2400"},
    {"X-RateLimit-Remaining", "2397"}, {"X-RateLimit-Reset", "1460397617"},
    {"ETag", "W/\"b492cdf6e384a62a4edde3da4bd35d78\""},
    {"Cache-Control", "max-age=0, private, must-revalidate"},
    {"X-Request-Id", "0d516f66-9801-480c-a467-85984b7ddbc8"},
    {"X-Runtime", "0.733693"},
    {"Strict-Transport-Security", "max-age=31536000"}], status_code: 200},
  rate_limit: 2400, rate_limit_remaining: 2397, rate_limit_reset: 1460397617}}

iex(6)> Dnsimple.RegistrarWhoisPrivacyService.whois_privacy(client, 63, "aaa-0001.com")
{:ok,
 %Dnsimple.Response{data: %Dnsimple.WhoisPrivacy{created_at: "2016-04-11T17:00:15.931Z",
   domain_id: 6156, enabled: false, expires_on: "2017-04-11", id: 159,
   updated_at: "2016-04-11T17:00:48.423Z"},
  http_response: %HTTPoison.Response{body: "{\"data\":{\"id\":159,\"domain_id\":6156,\"expires_on\":\"2017-04-11\",\"enabled\":false,\"created_at\":\"2016-04-11T17:00:15.931Z\",\"updated_at\":\"2016-04-11T17:00:48.423Z\"}}",
   headers: [{"Server", "nginx"}, {"Date", "Mon, 11 Apr 2016 17:00:58 GMT"},
    {"Content-Type", "application/json; charset=utf-8"},
    {"Transfer-Encoding", "chunked"}, {"Connection", "keep-alive"},
    {"Status", "200 OK"}, {"X-RateLimit-Limit", "2400"},
    {"X-RateLimit-Remaining", "2396"}, {"X-RateLimit-Reset", "1460397617"},
    {"ETag", "W/\"b492cdf6e384a62a4edde3da4bd35d78\""},
    {"Cache-Control", "max-age=0, private, must-revalidate"},
    {"X-Request-Id", "49868016-a605-42a2-a61b-1362fe7eac66"},
    {"X-Runtime", "0.121395"},
    {"Strict-Transport-Security", "max-age=31536000"}], status_code: 200},
  rate_limit: 2400, rate_limit_remaining: 2396, rate_limit_reset: 1460397617}}
```