### PR TITLE
Fix typespecs for Zones.update_zone_record/6 and Zones.create_zone_record/5

### DIFF
--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -191,7 +191,7 @@ defmodule Dnsimple.Zones do
       })
 
   """
-  @spec create_zone_record(Client.t, String.t | integer, String.t | integer, Keyword.t, Keyword.t) :: {:ok|:error, Response.t}
+  @spec create_zone_record(Client.t, String.t | integer, String.t | integer, map(), Keyword.t) :: {:ok|:error, Response.t}
   def create_zone_record(client, account_id, zone_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_id}/records")
 
@@ -212,7 +212,7 @@ defmodule Dnsimple.Zones do
       })
 
   """
-  @spec update_zone_record(Client.t, String.t | integer, String.t | integer, integer, Keyword.t, Keyword.t) :: {:ok|:error, Response.t}
+  @spec update_zone_record(Client.t, String.t | integer, String.t | integer, integer, map(), Keyword.t) :: {:ok|:error, Response.t}
   def update_zone_record(client, account_id, zone_id, record_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_id}/records/#{record_id}")
 


### PR DESCRIPTION
You have to send a map through for the attributes, not a keyword list. The keyword list is only for the options. If you try to send a keyword list for the attributes you get a Poison encoding error and the API call fails.