### PR TITLE
Add domain push identifier support and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Added `new_account_identifier` option to `initiate_push` for initiating domain pushes by account identifier.
+- Added `name` to `Account`.
+
+### Deprecated
+
+- Deprecated `new_account_email` option in `initiate_push`. Use `new_account_identifier` instead.
+
 ## 8.2.0 - 2026-03-23
 
 ### Added

--- a/lib/dnsimple/account.ex
+++ b/lib/dnsimple/account.ex
@@ -10,9 +10,10 @@ defmodule Dnsimple.Account do
   @type t :: %__MODULE__{
     id: integer,
     email: String.t,
+    name: String.t,
     plan_identifier: String.t,
   }
 
-  defstruct ~w(id email plan_identifier)a
+  defstruct ~w(id email name plan_identifier)a
 
 end

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -409,10 +409,10 @@ defmodule Dnsimple.Domains do
 
       client = %Dnsimple.Client{access_token: "a1b2c3d4"}
       {:ok, response} = Dnsimple.Domains.initiate_push(client, account_id = 1010, domain_id = "example.com", %{
-        new_domain_push_identifier: "abc123",
+        new_account_identifier: "abc123",
       })
 
-  Note: `new_account_email` is deprecated in favor of `new_domain_push_identifier`.
+  Note: `new_account_email` is deprecated in favor of `new_account_identifier`.
 
   """
   @spec initiate_push(Client.t, String.t | integer, String.t | integer, map, Keyword.t) :: {:ok|:error, Response.t}

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -409,8 +409,10 @@ defmodule Dnsimple.Domains do
 
       client = %Dnsimple.Client{access_token: "a1b2c3d4"}
       {:ok, response} = Dnsimple.Domains.initiate_push(client, account_id = 1010, domain_id = "example.com", %{
-        new_account_email: "other@example.com",
+        new_domain_push_identifier: "abc123",
       })
+
+  Note: `new_account_email` is deprecated in favor of `new_domain_push_identifier`.
 
   """
   @spec initiate_push(Client.t, String.t | integer, String.t | integer, map, Keyword.t) :: {:ok|:error, Response.t}

--- a/test/dnsimple/accounts_test.exs
+++ b/test/dnsimple/accounts_test.exs
@@ -31,6 +31,7 @@ defmodule Dnsimple.AccountsTest do
         assert Enum.all?(data, fn(element) -> element.__struct__ == Dnsimple.Account end)
         assert Enum.all?(data, fn(element) -> is_integer(element.id) end)
         assert Enum.all?(data, fn(element) -> is_binary(element.email) end)
+        assert Enum.all?(data, fn(element) -> is_binary(element.name) end)
         assert Enum.all?(data, fn(element) -> is_binary(element.plan_identifier) end)
       end
     end

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -413,6 +413,27 @@ defmodule Dnsimple.DomainsTest do
   end
 
 
+  describe ".initiate_push with domain push identifier" do
+    test "initiates the push using new_domain_push_identifier" do
+      url        = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/pushes"
+      method     = "post"
+      fixture    = "initiatePush/success.http"
+      attributes = %{new_domain_push_identifier: "abc123"}
+      body       = Poison.encode!(attributes)
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do
+        {:ok, response} = @module.initiate_push(@client, @account_id, @domain_id, attributes)
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.Push
+        assert data.id == 1
+        assert data.account_id == 2020
+      end
+    end
+  end
+
+
   @push_id 6789
 
 

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -413,12 +413,12 @@ defmodule Dnsimple.DomainsTest do
   end
 
 
-  describe ".initiate_push with domain push identifier" do
-    test "initiates the push using new_domain_push_identifier" do
+  describe ".initiate_push with account identifier" do
+    test "initiates the push using new_account_identifier" do
       url        = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/pushes"
       method     = "post"
       fixture    = "initiatePush/success.http"
-      attributes = %{new_domain_push_identifier: "abc123"}
+      attributes = %{new_account_identifier: "abc123"}
       body       = Poison.encode!(attributes)
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do

--- a/test/fixtures.http/accounts/success-account.http
+++ b/test/fixtures.http/accounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/test/fixtures.http/accounts/success-user.http
+++ b/test/fixtures.http/accounts/success-user.http
@@ -17,5 +17,5 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
 

--- a/test/fixtures.http/listAccounts/success-account.http
+++ b/test/fixtures.http/listAccounts/success-account.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"}]}

--- a/test/fixtures.http/listAccounts/success-user.http
+++ b/test/fixtures.http/listAccounts/success-user.http
@@ -17,4 +17,4 @@ x-permitted-cross-domain-policies: none
 x-xss-protection: 1; mode=block
 strict-transport-security: max-age=31536000
 
-{"data":[{"id":123,"email":"john@example.com","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}
+{"data":[{"id":123,"email":"john@example.com","name":"John","plan_identifier":"dnsimple-personal","created_at":"2011-09-11T17:15:58Z","updated_at":"2016-06-03T15:02:26Z"},{"id":456,"email":"ops@company.com","name":"Ops Company","plan_identifier":"teams-v1-monthly","created_at":"2012-03-16T16:02:54Z","updated_at":"2016-06-14T11:23:16Z"}]}

--- a/test/fixtures.http/whoami/success-account.http
+++ b/test/fixtures.http/whoami/success-account.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}

--- a/test/fixtures.http/whoami/success.http
+++ b/test/fixtures.http/whoami/success.http
@@ -12,4 +12,4 @@ x-request-id: 15a7f3a5-7ee5-4e36-ac5a-8c21c2e1fffd
 x-runtime: 0.141588
 strict-transport-security: max-age=31536000
 
-{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}
+{"data":{"user":null,"account":{"id":1,"email":"example-account@example.com","name":"Example Account","plan_identifier":"teams-v1-monthly","created_at":"2015-09-18T23:04:37Z","updated_at":"2016-06-09T20:03:39Z"}}}


### PR DESCRIPTION
## Summary
- Add `new_domain_push_identifier` parameter for domain pushes
- Deprecate `new_account_email` in favor of `new_domain_push_identifier`
- Add `name` field to `Account` struct
- Update fixtures and tests

Closes dnsimple/dnsimple-engineering#425