### PR TITLE
Support trustee service in transfers

### DIFF
--- a/lib/dnsimple/domain_transfer.ex
+++ b/lib/dnsimple/domain_transfer.ex
@@ -14,13 +14,14 @@ defmodule Dnsimple.DomainTransfer do
     state: String.t,
     auto_renew: boolean,
     whois_privacy: boolean,
+    trustee_service: boolean,
     status_description: String.t,
     created_at: String.t,
     updated_at: String.t,
   }
 
   defstruct ~w(id domain_id registrant_id
-               state auto_renew whois_privacy status_description
+               state auto_renew whois_privacy trustee_service status_description
                created_at updated_at)a
 
 end

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -181,6 +181,7 @@ defmodule Dnsimple.RegistrarTest do
         assert data.state == "transferring"
         assert data.auto_renew == false
         assert data.whois_privacy == false
+        assert data.trustee_service == false
         assert data.created_at == "2016-12-09T19:43:41Z"
         assert data.updated_at == "2016-12-09T19:43:43Z"
       end
@@ -205,6 +206,7 @@ defmodule Dnsimple.RegistrarTest do
         assert data.state == "cancelled"
         assert data.auto_renew == false
         assert data.whois_privacy == false
+        assert data.trustee_service == false
         assert data.status_description == "Canceled by customer"
         assert data.created_at == "2020-06-05T18:08:00Z"
         assert data.updated_at == "2020-06-05T18:10:01Z"
@@ -230,6 +232,7 @@ defmodule Dnsimple.RegistrarTest do
         assert data.state == "transferring"
         assert data.auto_renew == false
         assert data.whois_privacy == false
+        assert data.trustee_service == false
         assert data.status_description == nil
         assert data.created_at == "2020-06-05T18:08:00Z"
         assert data.updated_at == "2020-06-05T18:08:04Z"


### PR DESCRIPTION
Updated **lib/dnsimple/domain_transfer.ex**
- Added `trustee_service` field to the `DomainTransfer` struct so the value is parsed from API responses

Addresses https://github.com/dnsimple/dnsimple-app/issues/34693
Belongs to https://github.com/dnsimple/dnsimple-business/issues/2641

## QA

(Optional for reviewers)

From the console (adjust `account_id`, `registrant_id`, `domain_name` and `base_url` accordingly) run `mix run qa_transfer_trustee.exs`

```elixir
token = System.get_env("TOKEN") || raise "ERROR: TOKEN environment variable is required"

client = %Dnsimple.Client{
  access_token: token,
  base_url: "http://api.dnsimple.localhost:3000"
}

account_id = 2
registrant_id = 27
domain_name = "example.com"

# Transfer a domain with trustee service enabled
case Dnsimple.Registrar.transfer_domain(client, account_id, domain_name, %{
       registrant_id: registrant_id,
       auth_code: "x1y2z3",
       trustee_service: true
     }) do
  {:ok, response} ->
    transfer = response.data

    IO.puts(
      "transfer domain_id=#{transfer.domain_id} trustee_service=#{transfer.trustee_service} state=#{transfer.state}"
    )

    # Get the domain transfer to verify
    {:ok, response} =
      Dnsimple.Registrar.get_domain_transfer(client, account_id, domain_name, transfer.id)

    transfer = response.data

    IO.puts(
      "get_transfer id=#{transfer.id} trustee_service=#{transfer.trustee_service} state=#{transfer.state}"
    )

  {:error, error} ->
    IO.puts(error.message)
end
```

#### QA results

```
HTTP 400: TLD .COM does not support trustee service
```

```
HTTP 400: Unable to complete transfer at the registrar. Invalid attribute value syntax [Parameter value syntax error; Invalid transfer authorisation code]
```

## Deployment Pre/Post tasks

- [x] PRE: Wait till release is ready to be made
- [x] POST: Create a release version

## Deployment Verification

- [x] Verify release is created