### PR TITLE
Remove deprecated Certificate contact_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `contact_id` field from the `Certificate` struct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.
+
 ## 8.3.0 - 2026-04-15
 
 ### Added

--- a/lib/dnsimple/certificate.ex
+++ b/lib/dnsimple/certificate.ex
@@ -17,7 +17,6 @@ defmodule Dnsimple.Certificate do
   @type t :: %__MODULE__{
     id: integer,
     domain_id: integer,
-    contact_id: integer,
     common_name: String.t,
     alternate_names: List.t,
     years: integer,
@@ -35,7 +34,7 @@ defmodule Dnsimple.Certificate do
     chain: String.t,
   }
 
-  defstruct ~w(id domain_id contact_id
+  defstruct ~w(id domain_id
                common_name alternate_names years csr state authority_identifier auto_renew
                created_at updated_at expires_at
                server root chain private_key)a

--- a/test/dnsimple/certificates_test.exs
+++ b/test/dnsimple/certificates_test.exs
@@ -62,7 +62,6 @@ defmodule Dnsimple.CertificatesTest do
         assert data.__struct__ == Dnsimple.Certificate
         assert data.id == 101967
         assert data.domain_id == 289333
-        assert data.contact_id == 2511
         assert data.common_name == "www.bingo.pizza"
         assert data.alternate_names == []
         assert data.auto_renew == false


### PR DESCRIPTION
## Summary

Remove the deprecated `contact_id` field from the `Certificate` defstruct. The field was deprecated on 2022-05-17 and is no longer required for certificate operations.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#987

## Test plan

- [x] Existing tests updated to not reference `contact_id`
- [x] Tests pass