### PR TITLE
Remove deprecated EmailForward from and to fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project uses [Semantic Versioning 2.0.0](http://semver.org/), the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## main
+
+### Removed
+
+- **BREAKING**: Removed the deprecated `from` and `to` fields from the `EmailForward` defstruct. Use `alias_email` and `destination_email` instead.
+
 ## 8.3.0 - 2026-04-15
 
 ### Added

--- a/lib/dnsimple/email_forward.ex
+++ b/lib/dnsimple/email_forward.ex
@@ -17,6 +17,6 @@ defmodule Dnsimple.EmailForward do
     updated_at: String.t,
   }
 
-  defstruct ~w(id domain_id from to alias_email destination_email active created_at updated_at)a
+  defstruct ~w(id domain_id alias_email destination_email active created_at updated_at)a
 
 end


### PR DESCRIPTION
## Summary

Remove the deprecated `from` and `to` fields from the `EmailForward` defstruct. These fields were renamed to `alias_email` and `destination_email` on 2021-01-25. The server stopped emitting them on 2026-02-24 and stopped accepting them as input on 2026-03-03.

This is a breaking change.

Tracking PR: dnsimple/dnsimple-developer#988

## Test plan

- [x] `mix test` passes